### PR TITLE
Updating bootstrap.sh to build the result of a Github PR

### DIFF
--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -92,13 +92,21 @@ fi
 buildbox-run "git clean -fdq"
 buildbox-run "git fetch -q"
 
-# Only reset to the branch if we're not on a tag
-if [ "$BUILDBOX_TAG" == "" ]
+if [ "$BUILDBOX_PULL_REQUEST" != "false" ]
 then
-buildbox-run "git reset --hard origin/$BUILDBOX_BRANCH"
+  echo "building result of pull request $BUILDBOX_PULL_REQUEST"
+  buildbox-run "git fetch origin +refs/pull/$BUILDBOX_PULL_REQUEST/merge:"
+  buildbox-run "git checkout -qf FETCH_HEAD"
+else
+  if [ "$BUILDBOX_TAG" == "" ]
+  then
+    # Only reset to the branch if we're not on a tag
+    buildbox-run "git reset --hard origin/$BUILDBOX_BRANCH"
+  fi
+    buildbox-run "git checkout -qf \"$BUILDBOX_COMMIT\""
 fi
 
-buildbox-run "git checkout -qf \"$BUILDBOX_COMMIT\""
+
 
 if [ "$BUILDBOX_SCRIPT_PATH" == "" ]
 then


### PR DESCRIPTION
If `$BUILDBOX_PULL_REQUEST` is anything other than `false`, we'll now check out the result of that merge into its destination branch. Works for PRs inside the project repo, or from an external fork. Not tested for anything other than Github.